### PR TITLE
Add choiceSelection event to Plyfe object

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,4 +57,5 @@ The bootstrap JS file creates a `Plyfe` global on `window`. It has the following
 - `createWidgets`: Creates all cards found by the `Plyfe.settings.selector`
 - `createWidget`: Create one widget manually by passing in the HTML element (e.g. `Plyfe.createWidget(document.getElementById('custom-widget'));`).
 - `onCardStart`: Callback function that is called with `card` and `user` objects each time a user first interacts with a card.
-- `onCardComple`: Callback function that is called with `card` and `user` objects each time a user completes a card.
+- `onCardComplete`: Callback function that is called with `card` and `user` objects each time a user completes a card.
+- `onChoiceSelection`: Callback function that is called with `card`, `user` and `choice` objects each time a user selects a choice when interacting with a card.

--- a/src/main.js
+++ b/src/main.js
@@ -69,18 +69,29 @@ define(function(require) {
     plyfeObj['onCard' + eventName].call(plyfeObj, card, user);
   }
 
+  function choiceEvent(data, eventName) {
+    var user = utils.objectMerge(data.user, {id: 0});
+    var card = utils.objectMerge(data.card, {id: 0, type: 'no_type'});
+    var choice = utils.objectMerge(data.choice, {id: 0, name: 'no_name', correct: null});
+
+    plyfeObj['onChoice' + eventName].call(plyfeObj, card, user, choice);
+  }
+
   switchboard.on('card:start', function(data) { cardEvent(data, 'Start'); });
   switchboard.on('card:complete', function(data) { cardEvent(data, 'Complete'); });
+  switchboard.on('choice:selection', function(data) { choiceEvent(data, 'Selection'); });
 
   var onCardStart = window.Plyfe && window.Plyfe.onCardStart || function(){} ;
   var onCardComplete = window.Plyfe && window.Plyfe.onCardComplete || function(){} ;
+  var onChoiceSelection = window.Plyfe && window.Plyfe.onChoiceSelection || function(){} ;
 
   var plyfeObj = {
     settings: settings,
     createWidgets: createWidgets,
     createWidget: createWidget,
     onCardStart: onCardStart,
-    onCardComplete: onCardComplete
+    onCardComplete: onCardComplete,
+    onChoiceSelection: onChoiceSelection
   };
 
   return plyfeObj;

--- a/tests/spec/api.js
+++ b/tests/spec/api.js
@@ -1,4 +1,4 @@
- /*global Plyfe */
+/*global Plyfe */
 describe('Api', function() {
   'use strict';
 
@@ -66,9 +66,6 @@ describe('Api', function() {
 
   it('should send card, user and choice data with choiceSelection', function(done) {
     Plyfe.onChoiceSelection = function(card, user, choice) {
-      expect(card).to.not.be(null);
-      expect(user).to.not.be(null);
-      expect(choice).to.not.be(null);
       expect(card.id).to.be(1);
       expect(card.type).to.be('trivia_challenge');
       expect(user.id).to.be(1);
@@ -89,9 +86,6 @@ describe('Api', function() {
 
   it('should send default data with choiceSelection', function(done) {
     Plyfe.onChoiceSelection = function(card, user, choice) {
-      expect(card).to.not.be(null);
-      expect(user).to.not.be(null);
-      expect(choice).to.not.be(null);
       expect(card.id).to.be(0);
       expect(card.type).to.be('no_type');
       expect(user.id).to.be(0);

--- a/tests/spec/api.js
+++ b/tests/spec/api.js
@@ -1,4 +1,4 @@
-/*global Plyfe */
+ /*global Plyfe */
 describe('Api', function() {
   'use strict';
 
@@ -20,7 +20,7 @@ describe('Api', function() {
     window.postMessage('plyfe:card:start' + '\n' + JSON.stringify(data), '*');
   });
 
-  it("should send default data with cardStart", function(done) {
+  it('should send default data with cardStart', function(done) {
     Plyfe.onCardStart = function(card, user) {
       expect(card).to.not.be(null);
       expect(user).to.not.be(null);
@@ -51,7 +51,7 @@ describe('Api', function() {
     window.postMessage('plyfe:card:complete' + '\n' + JSON.stringify(data), '*');
   });
 
-  it("should send default data with cardComplete", function(done) {
+  it('should send default data with cardComplete', function(done) {
     Plyfe.onCardComplete = function(card, user) {
       expect(card).to.not.be(null);
       expect(user).to.not.be(null);
@@ -64,4 +64,43 @@ describe('Api', function() {
     window.postMessage('plyfe:card:complete' + '\n' + JSON.stringify({}), '*');
   });
 
+  it('should send card, user and choice data with choiceSelection', function(done) {
+    Plyfe.onChoiceSelection = function(card, user, choice) {
+      expect(card).to.not.be(null);
+      expect(user).to.not.be(null);
+      expect(choice).to.not.be(null);
+      expect(card.id).to.be(1);
+      expect(card.type).to.be('trivia_challenge');
+      expect(user.id).to.be(1);
+      expect(choice.id).to.be(1);
+      expect(choice.name).to.be('Choice 1');
+      expect(choice.correct).to.be(true);
+      done();
+    };
+
+    var data = {
+      card: { id: 1, type: 'trivia_challenge' },
+      user: { id: 1 },
+      choice: { id: 1, name: 'Choice 1', correct: true }
+    };
+
+    window.postMessage('plyfe:choice:selection' + '\n' + JSON.stringify(data), '*');
+  });
+
+  it('should send default data with choiceSelection', function(done) {
+    Plyfe.onChoiceSelection = function(card, user, choice) {
+      expect(card).to.not.be(null);
+      expect(user).to.not.be(null);
+      expect(choice).to.not.be(null);
+      expect(card.id).to.be(0);
+      expect(card.type).to.be('no_type');
+      expect(user.id).to.be(0);
+      expect(choice.id).to.be(0);
+      expect(choice.name).to.be('no_name');
+      expect(choice.correct).to.be(null);
+      done();
+    };
+
+    window.postMessage('plyfe:choice:selection' + '\n' + JSON.stringify({}), '*');
+  });
 });


### PR DESCRIPTION
Includes spec tests. Separates choice selection from card events to be a separate choice event with additional choice default object.